### PR TITLE
Add DevelopmentProject to single-cell samplesheets [Header]

### DIFF
--- a/data/singlecell/CTG_SampleSheet.csv
+++ b/data/singlecell/CTG_SampleSheet.csv
@@ -1,5 +1,6 @@
 [Header]
 FileFormatVersion,1
+DevelopmentProject,No
 [Settings]
 CreateFastqForIndexReads,0
 [Data]

--- a/main.py
+++ b/main.py
@@ -53,6 +53,10 @@ def upload_singlecell():
         else:
             singleindex = False
             samplesheet_columns = ["Sample_ID", "Sample_Project", "index", "index2"]
+        if (request.form.get("dev-project") =="true"):
+            development_status = True
+        else:
+            development_status = False
         # Process the sample info configuration
         samplesheet_info = combine_filestreams(
             request.files.getlist("samplesheets"), samplesheet_columns
@@ -91,7 +95,7 @@ def upload_singlecell():
             )
 
         samplesheet = generate_singlecell_sheet(
-            samplesheet_info, flexdata, feature_ref, singleindex
+            samplesheet_info, flexdata, feature_ref, singleindex, development_status
         )
         response = make_response(samplesheet)
         response.headers["Content-Type"] = "text/csv"
@@ -118,8 +122,8 @@ def upload_lab_report():
         return render_template("lab_report.html")
 
 
-def generate_singlecell_sheet(csv_data, flexfile, feature_ref, singleindex):
-    samplesheet = singleCellSheet(csv_data, flexfile, feature_ref, singleindex)
+def generate_singlecell_sheet(csv_data, flexfile, feature_ref, singleindex, development_status):
+    samplesheet = singleCellSheet(csv_data, flexfile, feature_ref, singleindex, development_status)
     samplesheet = samplesheet.dataDf
     return samplesheet
 

--- a/samplesheet.py
+++ b/samplesheet.py
@@ -3,9 +3,10 @@ import re
 
 
 class singleCellSheet:
-    def __init__(self, data_csv, flexfile, feature_ref, singleindex: bool):
+    def __init__(self, data_csv, flexfile, feature_ref, singleindex: bool, development_status: bool):
         # attempt to open data with pandas
         self.singleindex = singleindex
+        self.development_status = development_status
         self.dataDf = data_csv
         self.flexfile = flexfile
         self.feature_ref = feature_ref
@@ -157,6 +158,10 @@ class singleCellSheet:
     def write_header(self):
         self.header = "[Header]\n"
         self.header += "FileFormatVersion,1\n"
+        if self.development_status:
+            self.header += "DevelopmentProject,Yes\n"
+        else:
+            self.header += "DevelopmentProject,No\n"
 
     def write_settings(self):
         self.settings = '[Settings]\n'

--- a/templates/singlecell_forms.html
+++ b/templates/singlecell_forms.html
@@ -28,6 +28,12 @@
           ATAC index SampleSheet ( check if true )
         </label>
         </div>
+        <div class="form-check border p-10">
+          <input class="form-check-input" type="checkbox" value="true" name="dev-project" id="dev-project">
+          <label class="form-check-label" for="dev-project">
+            Development project ( check if true )
+          </label>
+          </div>
     </div>
     <button type="submit" class="btn btn-primary">Submit</button>
   </form>

--- a/test.py
+++ b/test.py
@@ -34,5 +34,5 @@ def test_samplesheet():
         "data/singlecell/flex_config.csv",
         "data/singlecell/CTG_SampleSheet.csv",
     )
-    samplesheet = singleCellSheet(ss, fc, fr, False)
+    samplesheet = singleCellSheet(ss, fc, fr, False, False)
     assert samplesheet.dataDf == ctg_samplesheet


### PR DESCRIPTION
Single cell samplesheets also uses the DevelopmentProject lingo as done in #29 

Output of the [Header] after checking dev-project checkbox:
```
[Header]
FileFormatVersion,1
DevelopmentProject,Yes
```
- [x] Passes pytest