### PR TITLE
Generalize samplesheet using PEP

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ def upload():
         response.headers["Content-Type"] = "text/csv"
         response.headers[
                 "Content-Disposition"
-            ] = f"attachment; filename=CTG_SampleSheet.csv"
+            ] = f"attachment; filename=CTG_SampleSheet_{request.form.get('flowcell')}.csv"
         return response
     else:
         return render_template("forms.html")

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ def upload():
         response.headers["Content-Type"] = "text/csv"
         response.headers[
             "Content-Disposition"
-        ] = f"attachment; filename=CTG_SampleSheet_{flowcell}.csv"
+        ] = f"attachment; filename=CTG_SampleSheet.csv"
         # under construction
         return response
     else:

--- a/main.py
+++ b/main.py
@@ -186,7 +186,7 @@ def make_raw(dev_project, flowcell, pid):
     that would be a flowcell ID and a project ID under a [Header]
     also probably dev project
     """
-    return f""""[Header]
+    return f"""[Header]
 FileFormatVersion,1,
 DevelopmentProject,{dev_project},
 Flowcell,{flowcell},

--- a/main.py
+++ b/main.py
@@ -35,7 +35,8 @@ def upload():
             projects_data = projects.stream.read().decode("utf-8")
             samplesheet = generate_genomics_sheet(samples_data, projects_data, request.form)
 
-        except:
+        except pd.errors.EmptyDataError:
+                
                     # dump rawdata
                 dev_project = 'No'
                 if request.form.get("checkbox_rawdata"):

--- a/main.py
+++ b/main.py
@@ -146,11 +146,7 @@ def generate_genomics_sheet(samples_data, projects_data, form):
         samplesheet.rc_indexes() 
     # generate samplesheet
     ss_string : str = ''
-    if form.get("checkbox_seqonly"):
-        samplesheet.seqonly_project = 'Yes'
-        ss_string = samplesheet.make_ss()
-    else:
-        ss_string = samplesheet.make_ss()   
+    ss_string = samplesheet.make_ss()   
 
     return ss_string, form.get("flowcell")
 

--- a/main.py
+++ b/main.py
@@ -39,6 +39,8 @@ def upload():
         ] = f"attachment; filename=CTG_SampleSheet_{flowcell}.csv"
         # under construction
         return response
+    else:
+        return render_template("forms.html")
 
 
 
@@ -128,7 +130,7 @@ def generate_singlecell_sheet(csv_data, flexfile, feature_ref, singleindex, deve
 
 
 def generate_genomics_sheet(samples_data, projects_data, form):
-    samplesheet = pep2samplesheet(StringIO(samples_data), StringIO(projects_data)
+    samplesheet = pep2samplesheet(StringIO(samples_data), StringIO(projects_data))
     # set params
     samplesheet.sequencer = form.get("sequencer")
     # dev project

--- a/main.py
+++ b/main.py
@@ -26,8 +26,8 @@ def handle_error(e):
 @app.route("/", methods=["GET", "POST"])
 def upload():
     if request.method == "POST":
-        samples = request.files["samples.csv"]
-        projects = request.files["projects.csv"]
+        samples = request.files["samples"]
+        projects = request.files["projects"]
         # Do something with the uploaded CSV file...
         samples_data = samples.stream.read().decode("utf-8")
         projects_data = projects.stream.read().decode("utf-8")

--- a/samplesheet.py
+++ b/samplesheet.py
@@ -465,9 +465,13 @@ class pep2samplesheet:
             raise Exception('Invalid sample_name found in PEP!')
         if not self.df['index'].str.match(self.index_pattern).all():
             raise Exception('Invalid index found in PEP!')
-        # check projects for the columns fastq,bam
-        if not self.projects.columns.isin(['project_id','fastq','bam']).all():
-            raise Exception('Missing columns in projects.csv!')
+        
+        # only check that columns exist
+        # projects df needs at least a project_id and a fastq column
+        if not 'project_id' in self.projects.columns:
+            raise Exception('project_id column not found in projects.csv!')
+        if not 'fastq' in self.projects.columns:
+            raise Exception('fastq column not found in projects.csv!')
         
     
     def make_ss(self):

--- a/samplesheet.py
+++ b/samplesheet.py
@@ -422,23 +422,17 @@ class pep2samplesheet:
     As decided we will create Illumina v1 samplesheets going forward
     due to the restrictiveness of v2
     """
-    def __init__(self, data_csv):
+    def __init__(self, data_csv, projects_csv):
         # init data
         self.data = data_csv
         self.df = pd.read_csv(data_csv)
+        self.projects = pd.read_csv(projects_csv)
         # Params
         self.sequencer = ''
         self.seqonly_project = 'No'
         # keep empty for testing
         self.flowcell = ''
         self.dev_project = 'No'
-        self.fastq = 'No'
-        self.bam = 'No'
-        self.bcl = 'No'
-        self.vcf = 'No'
-        self.rnacounts = 'No'
-        self.fastqc = 'No'
-        self.fastqscreen = 'No'
         # init patterns
         self.project_id_pattern = re.compile(r'^\d{4}_\d{3}$')
         self.sample_name_pattern = re.compile(r'^[0-9A-Za-z_-]+$')
@@ -482,8 +476,6 @@ class pep2samplesheet:
         ss_1_string = "[Header]\nFileFormatVersion,1,\n"
         # sequencer
         ss_1_string += f"Sequencer,{self.sequencer},\n"
-        # seqonly project
-        ss_1_string += f"SeqOnlyProject,{self.seqonly_project},\n"
         # dev project
         ss_1_string += f"DevelopmentProject,{self.dev_project},\n"
         # flowcell
@@ -500,6 +492,17 @@ class pep2samplesheet:
         str_df = '\n'.join(str_df)
         # Append the string to the samplesheet
         ss_1_string += str_df
+        # rename columns in projects.csv
+        self.projects.rename(columns=self.column_map, inplace=True)
+        # convert self.projects to a string
+        str_projects = self.projects.apply(lambda x: ','.join(x.astype(str)), axis=1)
+        # join the rows with a newline
+        str_projects = '\n'.join(str_projects)
+        # append the string to the samplesheet
+        ss_1_string += "\n\n[Projects_Data]\n"
+        ss_1_string += ",".join(self.projects.columns) + "\n"
+        ss_1_string += str_projects
+        # return the string
         return ss_1_string
     
     def reverse_complement(self, nucleotide_string):

--- a/samplesheet.py
+++ b/samplesheet.py
@@ -488,20 +488,6 @@ class pep2samplesheet:
         ss_1_string += f"DevelopmentProject,{self.dev_project},\n"
         # flowcell
         ss_1_string += f"Flowcell,{self.flowcell},\n"
-        # fastq
-        ss_1_string += f"Fastq,{self.fastq},\n"
-        # bam
-        ss_1_string += f"Bam,{self.bam},\n"
-        # bcl
-        ss_1_string += f"Bcl,{self.bcl},\n"
-        # vcf
-        ss_1_string += f"Vcf,{self.vcf},\n"
-        # rnacounts
-        ss_1_string += f"RnaCounts,{self.rnacounts},\n"
-        # fastqc
-        ss_1_string += f"Fastqc,{self.fastqc},\n"
-        # fastqscreen
-        ss_1_string += f"Fastqscreen,{self.fastqscreen},\n"
         # data
         ss_1_string += "\n[Data]\n"
         # rename columns

--- a/samplesheet.py
+++ b/samplesheet.py
@@ -465,6 +465,9 @@ class pep2samplesheet:
             raise Exception('Invalid sample_name found in PEP!')
         if not self.df['index'].str.match(self.index_pattern).all():
             raise Exception('Invalid index found in PEP!')
+        # check projects for the columns fastq,bam
+        if not self.projects.columns.isin(['project_id','fastq','bam']).all():
+            raise Exception('Missing columns in projects.csv!')
         
     
     def make_ss(self):

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -13,6 +13,12 @@
       <label for="Dev">Dev</label>
       <input type="checkbox" id="checkbox_dev" name="checkbox_dev">
       <div></div>
+      <h3>Raw data only?</h3>
+      <label for="Raw">Raw</label>
+      <input type="checkbox" id="checkbox_raw" name="checkbox_raw">
+        <label for="pid">Project ID</label>
+        <input type="text" id="pid" name="pid">
+      <div></div>
       <h3>Flowcell serial number:</h3>
       <input type="text" id="flowcell" name="flowcell">
       <div></div>
@@ -38,4 +44,5 @@
   </div>
     <button type="submit" class="btn btn-primary">Submit</button>
   </form>
+
 {% endblock %}

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -41,7 +41,6 @@
       <label for="projects">Upload projects.csv</label>
       <input type="file" class="form-control-file" id="projects" name="projects">
   </div>
-
     <button type="submit" class="btn btn-primary">Submit</button>
   </form>
 {% endblock %}

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -20,30 +20,6 @@
       <h3>Flowcell serial number:</h3>
       <input type="text" id="flowcell" name="flowcell">
       <div></div>
-      <h2>Data Deliverables</h2>
-      <div></div>
-      <label for="BCL">BCL</label>
-      <input type="checkbox" id="checkbox_bcl" name="checkbox_bcl">
-      <div></div>
-      <label for="Fastq">Fastq</label>
-      <input type="checkbox" id="checkbox_fastq" name="checkbox_fastq" checked>
-      <div></div>
-      <label for="Bam">Bam</label>
-      <input type="checkbox" id="checkbox_bam" name="checkbox_bam">
-      <div></div>
-      <label for="Vcf">Vcf</label>
-      <input type="checkbox" id="checkbox_vcf" name="checkbox_vcf">
-      <div></div>
-      <label for="RNA Count matrix">RNA count matrix</label>
-      <input type="checkbox" id="checkbox_rnacount" name="checkbox_rnacount"> 
-      <div></div>
-      <h2>Quality Control deliverables</h2>
-      <div></div>
-      <label for="Fastqc">Fastqc</label>
-      <input type="checkbox" id="checkbox_fastqc" name="checkbox_fastqc" checked>
-      <label for="Fastqscreen">Fastqscreen</label>
-      <input type="checkbox" id="checkbox_fastqscreen" name="checkbox_fastqscreen">
-      <div></div>
       <h2>Reverse Complement Index2?</h2>
       <label for="RC">RC Index2</label>
       <input type="checkbox" id="checkbox_rc" name="checkbox_rc">
@@ -58,9 +34,13 @@
         </select>
     </div>
     <div class="form-group">
-        <label for="csvfile">Upload the CSV</label>
-        <input type="file" class="form-control-file" id="csvfile" name="csvfile">
+        <label for="samples">Upload samples.csv</label>
+        <input type="file" class="form-control-file" id="samples" name="samples">
     </div>
+    <div class="form-group">
+      <label for="projects">Upload projects.csv</label>
+      <input type="file" class="form-control-file" id="projects" name="projects">
+  </div>
 
     <button type="submit" class="btn btn-primary">Submit</button>
   </form>

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -19,8 +19,7 @@
       <h2>Reverse Complement Index2?</h2>
       <label for="RC">RC Index2</label>
       <input type="checkbox" id="checkbox_rc" name="checkbox_rc">
-      
-  </div>
+    </div>
     <div class="form-group">
         <label for="select">Select which sequencer</label>
         <select class="form-control" id="select" name="sequencer">

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -17,7 +17,7 @@
       <label for="Raw">Raw</label>
       <input type="checkbox" id="checkbox_raw" name="checkbox_raw">
         <label for="pid">Project ID</label>
-        <input type="text" id="pid" name="pid">
+        <input type="text" id="pid" name="pid" pattern="^\d{4}_\d{3}$">
       <div></div>
       <h3>Flowcell serial number:</h3>
       <input type="text" id="flowcell" name="flowcell">

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -7,11 +7,7 @@
 {% block content %}
   <h1>Check all that applies</h1>
   <form method="POST" enctype="multipart/form-data">
-    <h2>Workflow</h2>
     <div class="form-group">
-      <h3>Uncheck if this is NOT sequencing only</h3>
-      <label for="SeqOnly">SeqOnly</label>
-      <input type="checkbox" id="checkbox_seqonly" name="checkbox_seqonly" checked>
       <div></div>
       <h3>Is this a dev project?</h3>
       <label for="Dev">Dev</label>

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -14,6 +14,9 @@
       <input type="checkbox" id="checkbox_dev" name="checkbox_dev">
       <div></div>
       <h3>Raw data only?</h3>
+      <br>
+      <p>For raw data we only need the flowcell and the project id, then you can press Submit!</p>
+      <br>
       <label for="Raw">Raw</label>
       <input type="checkbox" id="checkbox_raw" name="checkbox_raw">
         <label for="pid">Project ID</label>
@@ -33,6 +36,41 @@
           <option value="Miseq">Miseq</option>
           <option value="Novaseq">Novaseq6000</option>
         </select>
+    </div>
+    <div>
+      <h3>Instructions:</h3>
+      <p>Download and fill out one samples.csv and one projects.csv.
+        The samples.csv is named after the analysis that we perform, eg
+        dna_samples.csv, rna_samples.csv and so on.
+        <br>
+
+        There is only one projects.csv (link below), when you open it you will find
+        that it tracks information on a project level whereas the samples.csv tracks
+        sample level information.
+        <br>
+        Lanes:<br>
+        The Lane column can be added to any samples.csv. 
+        Samples must be specified with one row for every lane that sample is found on.
+        <br>
+        Eg:<br>
+        Sample1, 1<br>
+        Sample1, 2<br>
+        Sample1, 3<br>
+        <br>
+        The above means we expect that sample to be found on lane 1, 2 and 3. 
+        <br>
+        All csv files can be found at the <a href="https://github.com/ctg-lund/Templates/tree/main/PEP/All">templates repo</a>
+        <br>
+        <br>
+        <a href="https://github.com/ctg-lund/Templates/blob/main/PEP/All/dna_samples.csv">dna_samples.csv</a>
+        <br>
+        <a href="https://github.com/ctg-lund/Templates/blob/main/PEP/All/rna_samples.csv">rna_samples.csv</a>
+        <br>
+        And the projects file:
+        <br>
+        <a href="https://github.com/ctg-lund/Templates/blob/main/PEP/All/projects.csv">projects.csv</a>
+      </p>
+
     </div>
     <div class="form-group">
         <label for="samples">Upload samples.csv</label>


### PR DESCRIPTION
This PR is the first step in implementing what we discussed this week.

Here is the file that we looked at together: 
```
[Header]
FileFormatVersion,1,
Sequencer,Nextseq 2000, # DONT MOVE
SeqOnlyProject,Yes,
DevelopmentProject,Yes, # DONT MOVE
Flowcell,AACHWK, # NECESSARY?
# MOVE BELOW TO Project_Data
Fastq,Yes,
Bam,No,
Bcl,No,
Vcf,No,
RnaCounts,Yes,
Fastqc,Yes,
Fastqscreen,No,

[Data]
Sample_ID,Sample_Project,index,index2
s1,2022_000,CACTCGCATA,GAACGCGACA
s2,2022_000,AAGGTGTACT,AGCGCTACAG
s3,2022_000,CAATGCGTGT,ATGTTCGCGC
s4,2022_000,TCACCGTGGT,TCGCTCTGCT

[Project_Data]
Project_ID,VCF,Bam,Fastq,BCL,RnaCounts
2022_000,Yes,Yes,No,No,Yes

[RNA_Data]
Sample_ID,Sample_Project,control,experiment,reference

[DNA_Data]
Sample_ID,Sample_Project,control,experiment,panel,reference

[Meth_Data]
Sample_ID,Sample_Project,control,experiment,reference
```

I prototyped the new PEPs under Templates:
https://github.com/ctg-lund/Templates/tree/main/PEP/All

There will be 2 ingoing CSV files that are filled out in the Lab. For seqonly projects the Lab fills out projects.csv and the customer fills out samples.csv

projects.csv
```
project_id,bcl,fastq,bam,vcf,rna_counts,differential_expression,fastqc,fastqscreen
2023_001,No,Yes,No,No,No,No,Yes,No
```

samples.csv
```
sample_name,project_id,index,index2
sample1,1999_001,AGAT,TAGA
sample2,1999_001,AGAT,TAGA
```

This will produce a samplesheet that looks like this:
CTG_SampleSheet_AAFGH.csv
```
[Header]
FileFormatVersion,1,
Sequencer,Nextseq 2000,
DevelopmentProject,No,
Flowcell,AADFGH,

[Data]
Sample_ID,Sample_Project,index,index2
sample1,1999_001,AGAT,TAGA
sample2,1999_001,AGAT,TAGA

[Projects_Data]
Sample_Project,bcl,fastq,bam,vcf,rna_counts,differential_expression,fastqc,fastqscreen
2023_001,No,Yes,No,No,No,No,Yes,No
```

Here comes a challenge - we agreed to add another abstraction. DNA dragen projects for example would have a [DNA_Data] section to save space in [Data].

I started out by extending the PEP specification with an amend statement, this means the samples.csv can be replaced with eg dna_samples.csv:
```
sample_name,project_id,index,index2,reference,control,experiment,panel
sample1,1999_001,AGAT,TAGA,hg38,control1,experiment1,GMCK
sample2,1999_001,AGAT,TAGA,hg38,control2,experiment2,GMCK
```

In the config.yaml:
```
pep_version: 2.1.0
sample_table: samples.csv
project_modifiers: 
  amend:
    dna_project:
      sample_table: dna_samples.csv
    rna_project:
      sample_table: rna_samples.csv
    methylation_project:
      sample_table: methylation_samples.csv
name: ctg
description: Prototype processing PEP for sequencing center
properties:
  samples:
    type: array
    items:
      type: object
      properties:
        project_id:
          type: string
          description: The serial number of the project given in the form YYYY_XXX
          pattern: ^\\d{4}_\\d{3}$
        sample_name:
          type: string
          description: The sample name A-Z,a-z, _ and - only! Pep specification index
            column. Don't change this name!
          pattern: ^[0-9A-Za-z_-]+$
        index:
          type: string
          description: The nucleotide sequence of the index
          pattern: ^[ATCG]+$
        index2:
          type: string
          description: The nucleotide sequence of the second index
          pattern: ^[ATCG]+$
        lane:
          type: integer
          description: The lane number
        reference:
          type: string
          description: The reference genome to use for alignment
        control:
          type: string
          description: Whether the sample is a control or not
          pattern: ^YES|NO|[Yy]es|[Nn]o$
        experiment:
          type: string
          description: The experiment type
        panel:
          type: string
          description: The panel used for targeted sequencing
      required:
      - project_id
      - sample_name
      - index
      - index2
required:
- samples

super_table: projects.csv
super_properties:
  projects:
    type: array
    items:
      type: object
      properties:
        project_id:
          type: string
          description: The serial number of the project given in the form YYYY_XXX
          pattern: ^\\d{4}_\\d{3}$
        bcl:
          type: string
          description: whether to deliver bcl files for this project, can only be
            yes or no
          pattern: ^YES|NO|[Yy]es|[Nn]o$
        fastq:
          type: string
          description: whether to deliver fastq files for this project, can only be
            yes or no
          default: true
          pattern: ^YES|NO|[Yy]es|[Nn]o$
        bam:
          type: string
          description: whether to deliver bam files for this project, can only be
            yes or no
          pattern: ^YES|NO|[Yy]es|[Nn]o$
        vcf:
          type: string
          description: whether to deliver vcf files for this project, can only be
            yes or no
          pattern: ^YES|NO|[Yy]es|[Nn]o$
        rna_counts:
          type: string
          description: whether to deliver raw rna counts for this project, can only
            be yes or no
          pattern: ^YES|NO|[Yy]es|[Nn]o$
        differential_expression:
          type: string
          description: whether to deliver diffexp results for this project, can only
            be yes or no
          pattern: ^YES|NO|[Yy]es|[Nn]o$
        fastqc:
          type: string
          description: whether to deliver fastqc reports for this project, can only
            be yes or no
          default: true
          pattern: ^YES|NO|[Yy]es|[Nn]o$
        fastqscreen:
          type: string
          description: whether to deliver fastqscreen reports for this project, can
            only be yes or no
          pattern: ^YES|NO|[Yy]es|[Nn]o$
      required: project_id
```
Essentially instead of defining a completely new table, I extend the basic sample.csv specification to include optional extra columns. 

Now on to the resulting problem:

The genomics section will just ask that you upload 2 files and then simply combine those files into the new samplesheet, this is simple to write and maintain and only depends on the lab adding the right info to the right csv, 

We could get data sections by combining the samples.csv and the projects csv.

A way to do this would be to take eg a protocol string from projects.csv, and use that information to move the relevant columns from the samples.csv into the appropriate [Protocol_Data] section. I think this is the simplest solution, as we would not have to eg dynamically add csvs or inputs in the form.

First this would lead to confusion for lab workers, for every project with a unique protocol on the same flowcell they would need to add columns from the appropriate example protocol_samples.csv until they have one with all projects, columns and samples. No doubt this introduces a lot of opportunity for human error, as well as being tedious.

Second - as we develop new protocols we would need to change the specifications and also the samplesheet generator to correctly implement the [Protocol_Data], we always need to do some of this, but subsetting and combining the info from the samplesheets makes it much harder than just adding a specification to the PEP.

Perhaps we can accept the second problem, as we gain more readability in the CLI, but I would say that the first problem blocks this approach until we get a LIMS and don't have to depend on manual labor of others so much when we construct our inputs.

My suggestion is then that the lab worker simply replaces samples.csv with the proper protocol.csv and that all of that info goes to [Data], the illumina v1 should work for that as that is exactly what was done before, however we should not put useless information there.

I propose we have a meeting as soon as possible next week to discuss this and how to move forward!