### PR TITLE
Validation patch 1

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,14 +39,16 @@ def upload():
                 
                     # dump rawdata
                 dev_project = 'No'
-                if request.form.get("checkbox_rawdata"):
+                if request.form.get("checkbox_raw"):
                     if request.form.get("checkbox_dev"):
                         dev_project = 'Yes'
-                    if not request.form.get("project_id"):
+                    if request.form.get("project_id") == "":
                         raise Exception("Project ID is required for raw data!")
-                    if not request.form.get("flowcell"):
+                    if request.form.get("flowcell") == "":
                         raise Exception("Flowcell serial number is required for raw data!")
-                samplesheet = make_raw(dev_project, request.form.get("flowcell"), request.form.get("pid"))
+                    samplesheet = make_raw(dev_project, request.form.get("flowcell"), request.form.get("pid"))
+                else:
+                    raise Exception("No data provided!")
 
         response = make_response(samplesheet)
         response.headers["Content-Type"] = "text/csv"

--- a/main.py
+++ b/main.py
@@ -42,9 +42,9 @@ def upload():
                 if request.form.get("checkbox_rawdata"):
                     if request.form.get("checkbox_dev"):
                         dev_project = 'Yes'
-                    if request.form.get("project_id") == '':
+                    if not request.form.get("project_id"):
                         raise Exception("Project ID is required for raw data!")
-                    if request.form.get("flowcell") == '':
+                    if not request.form.get("flowcell"):
                         raise Exception("Flowcell serial number is required for raw data!")
                 samplesheet = make_raw(dev_project, request.form.get("flowcell"), request.form.get("pid"))
 

--- a/main.py
+++ b/main.py
@@ -27,28 +27,24 @@ def handle_error(e):
 def upload():
     if request.method == "POST":
         # normal project
-        try:
+        if request.form.get("checkbox_raw"):
+            # dump rawdata
+            dev_project = 'No'
+            if request.form.get("checkbox_raw"):
+                if request.form.get("checkbox_dev"):
+                    dev_project = 'Yes'
+                if request.form.get("project_id") == "":
+                    raise Exception("Project ID is required for raw data!")
+                if request.form.get("flowcell") == "":
+                    raise Exception("Flowcell serial number is required for raw data!")
+                samplesheet = make_raw(dev_project, request.form.get("flowcell"), request.form.get("pid"))
+        else:   
             samples = request.files["samples"]
             projects = request.files["projects"]
             # Do something with the uploaded CSV file...
             samples_data = samples.stream.read().decode("utf-8")
             projects_data = projects.stream.read().decode("utf-8")
             samplesheet = generate_genomics_sheet(samples_data, projects_data, request.form)
-
-        except pd.errors.EmptyDataError:
-                
-                    # dump rawdata
-                dev_project = 'No'
-                if request.form.get("checkbox_raw"):
-                    if request.form.get("checkbox_dev"):
-                        dev_project = 'Yes'
-                    if request.form.get("project_id") == "":
-                        raise Exception("Project ID is required for raw data!")
-                    if request.form.get("flowcell") == "":
-                        raise Exception("Flowcell serial number is required for raw data!")
-                    samplesheet = make_raw(dev_project, request.form.get("flowcell"), request.form.get("pid"))
-                else:
-                    raise Exception("No data provided!")
 
         response = make_response(samplesheet)
         response.headers["Content-Type"] = "text/csv"

--- a/samplesheet.py
+++ b/samplesheet.py
@@ -465,6 +465,22 @@ class pep2samplesheet:
             raise Exception('Invalid sample_name found in PEP!')
         if not self.df['index'].str.match(self.index_pattern).all():
             raise Exception('Invalid index found in PEP!')
+        # valid columns for samples.csv are:
+        # project_id, sample_name, index, index2, reference, experiment, control, lane
+        valid_columns = ['project_id', 
+                         'sample_name', 
+                         'index', 
+                         'index2', 
+                         'reference', 
+                         'experiment', 
+                         'control', 
+                         'lane', 
+                         'Lane',
+                         'panel'
+                         ]
+        for col in self.df.columns:
+            if col not in valid_columns:
+                raise Exception(f'Invalid column found in samples.csv: {col}')
         
         # only check that columns exist
         # projects df needs at least a project_id and a fastq column

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -17,7 +17,7 @@
       <br>
       <p>For unindexed fastqs we only need the flowcell and the project id, then you can press Submit!</p>
       <br>
-      <label for="Raw">Raw</label>
+      <label for="Raw">Unindexed Fastqs</label>
       <input type="checkbox" id="checkbox_raw" name="checkbox_raw">
         <label for="pid">Project ID</label>
         <input type="text" id="pid" name="pid" pattern="^\d{4}_\d{3}$">

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -13,9 +13,9 @@
       <label for="Dev">Dev</label>
       <input type="checkbox" id="checkbox_dev" name="checkbox_dev">
       <div></div>
-      <h3>Raw data only?</h3>
+      <h3>Unindexed data only?</h3>
       <br>
-      <p>For raw data we only need the flowcell and the project id, then you can press Submit!</p>
+      <p>For unindexed fastqs we only need the flowcell and the project id, then you can press Submit!</p>
       <br>
       <label for="Raw">Raw</label>
       <input type="checkbox" id="checkbox_raw" name="checkbox_raw">
@@ -23,7 +23,7 @@
         <input type="text" id="pid" name="pid" pattern="^\d{4}_\d{3}$">
       <div></div>
       <h3>Flowcell serial number:</h3>
-      <input type="text" id="flowcell" name="flowcell">
+      <input type="text" id="flowcell" name="flowcell" pattern="^\w+$">
       <div></div>
       <h2>Reverse Complement Index2?</h2>
       <label for="RC">RC Index2</label>
@@ -35,6 +35,7 @@
           <option value="Nextseq 2000">Nextseq2000</option>
           <option value="Miseq">Miseq</option>
           <option value="Novaseq">Novaseq6000</option>
+          <option value="Novaseq">NovaseqX</option>
         </select>
     </div>
     <div>


### PR DESCRIPTION
pep2samplesheet now includes a list of names that are acceptable in input data columns
why: because it is possible the lab uses davids excel and then pastes the information into a csv that they upload as
samples.csv and they might accidentally add unneccesary or unwanted columns

minor regex to make html tooltip that FC should be filled out, this just extends the existing validation on FC

improved the logic by replacing the try except with an if else

also changed some wording that was brought up by lab

What has been tested:
![image](https://github.com/ctg-lund/SampleSheetGenerator/assets/51265018/11a328d5-caf8-41cf-8852-382c01e38887)
empty flowcell + raw data = error message
![image](https://github.com/ctg-lund/SampleSheetGenerator/assets/51265018/afa7bfda-d642-463c-bc44-a0e9674945f9)
A properly filled out raw ss:
```
[Header]
FileFormatVersion,1,
DevelopmentProject,No,
Flowcell,FSDFSDF,
Project_ID,2023_174,
```

A properly filled out dna ss:
```
[Header]
FileFormatVersion,1,
Sequencer,Nextseq 2000,
DevelopmentProject,No,
Flowcell,FSDFSDF,

[Data]
Sample_ID,Sample_Project,index,index2,reference,control,experiment,panel
sample1,1999_001,AGAT,TAGA,hg38,control1,experiment1,GMCK
sample2,1999_001,AGAT,TAGA,hg38,control2,experiment2,GMCK

[Projects_Data]
Sample_Project,bcl,fastq,bam,vcf,rna_counts,differential_expression,fastqc,fastqscreen
2023_001,No,Yes,No,No,No,No,Yes,No
```

An improperly filled out samples.csv:
```
sample_name,project_id,index,index2,whatever
A_control,2022_179,CACTCGCATA,GAACGCGACA
B_Volasertib,2022_179,AAGGTGTACT,AGCGCTACAG
C_pos_cont,2022_179,CAATGCGTGT,ATGTTCGCGC
D_neg_cont,2022_179,TCACCGTGGT,TCGCTCTGCT
```
![image](https://github.com/ctg-lund/SampleSheetGenerator/assets/51265018/ec7ee9bd-a515-4671-8711-fe04524f0ec0)
