### PR TITLE
find and report duplicates

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import pandas as pd
 import sys
 import traceback
 from pprint import pprint
+import re
 
 app = Flask(__name__)
 
@@ -19,9 +20,13 @@ app.wsgi_app = DispatcherMiddleware(
 @app.errorhandler(Exception)
 def handle_error(e):
     etype, value, tb = sys.exc_info()
-    print(traceback.print_exception(etype, value, tb))
-    return render_template("error.html", e=e), 500
-
+    traceback_lines = traceback.format_exception(etype, value, tb)
+    traceback_string = "".join(traceback_lines)
+    traceback_html = traceback_string.replace('\n', '<br>')
+    # also find the line that starts with Exception: and make it
+    # a html header 4
+    traceback_html = re.sub(r'Exception:', r'<h4>\g<0></h4>', traceback_html) 
+    return render_template("error.html", traceback_lines=traceback_html), 500
 
 @app.route("/", methods=["GET", "POST"])
 def upload():

--- a/templates/error.html
+++ b/templates/error.html
@@ -3,16 +3,10 @@
 {% block title %}Error{% endblock %}
 
 {% block content %}
-  <div class="row">
-    <div class="col-md-12">
-      <div class="alert alert-danger" role="alert">
-        <h4 class="alert-heading">An error occurred</h4>
-        <p>Something went wrong while processing your request. Please try again later.</p>
-        <hr>
-          {% if e %}
-            <p class="mb-0">Error message: {{ e }}</p>
-          {% endif %}
-      </div>
-    </div>
-  </div>
+<h1>An error occurred:</h1>
+<body>
+    <h1>Oops!</h1>
+    <p>Sorry, but an error occurred.</p>
+    <p>Here's a traceback for debugging purposes:</p>
+    <p>{{ traceback_lines|safe }}</p>
 {% endblock %}


### PR DESCRIPTION
Problem:

Sometimes samplesheets are accidentally created that will contain duplicate indexe-pairs.

It is fine to have duplicate index-pairs on the same flowcell if and only if a lane divider is used to keep duplicates separate.

Solution:
SamplesheetGenerator now finds out of the sample.csv contains a lane column

If there is a lane column
check if there is more than one value
eg
sample_name,lane
s1,1
s1,2
this means we have a lane divider

so then, check that for each lane - there are no duplicate index pairs

if not lane divider
check for duplicates across all indexes

misc changes
the pep2samplsheet object has properties for lane divider and shared flowcell
it checks and sets this value when an instance is created

the following was used to test:

projects.csv always same 
[projects.csv](https://github.com/ctg-lund/SampleSheetGenerator/files/12487030/projects.csv)

Works OK
```
sample_name,project_id,index,index2
A_control,2022_179,CACTCGCATA,GAACGCGACA
B_Volasertib,2022_179,AAGGTGTACT,AGCGCTACAG
C_pos_cont,2022_179,CAATGCGTGT,ATGTTCGCGC
D_neg_cont,2022_179,TCACCGTGGT,TCGCTCTGCT
```

Works OK
```
sample_name,project_id,index,index2,lane
A_control,2022_179,CACTCGCATA,GAACGCGACA,1
B_Volasertib,2022_179,AAGGTGTACT,AGCGCTACAG,1
C_pos_cont,2022_179,CAATGCGTGT,ATGTTCGCGC,1
D_neg_cont,2022_179,TCACCGTGGT,TCGCTCTGCT,1
anotther_sample,2022_179,TCACCGTGGT,TCGCTCTGCT,2
```

SHOULD NOT WORK
```
sample_name,project_id,index,index2
A_control,2022_179,CACTCGCATA,GAACGCGACA
B_Volasertib,2022_179,AAGGTGTACT,AGCGCTACAG
C_pos_cont,2022_179,CAATGCGTGT,ATGTTCGCGC
D_neg_cont,2022_179,TCACCGTGGT,TCGCTCTGCT
anotther_sample,2022_179,TCACCGTGGT,TCGCTCTGCT
```

```
sample_name,project_id,index,index2,lane
A_control,2022_179,CACTCGCATA,GAACGCGACA,1
B_Volasertib,2022_179,AAGGTGTACT,AGCGCTACAG,1
C_pos_cont,2022_179,CAATGCGTGT,ATGTTCGCGC,1
D_neg_cont,2022_179,TCACCGTGGT,TCGCTCTGCT,1
anotther_sample,2022_179,TCACCGTGGT,TCGCTCTGCT,1
D_neg_cont_2,2022_179,TCACCGTGGT,TCGCTCTGCT,2
```

The above works as expected and throws errors that are printed to the web page like this:
![image](https://github.com/ctg-lund/SampleSheetGenerator/assets/51265018/64790c84-1611-436c-8a2a-c9e0ea6317cd)







