### PR TITLE
label RC with novaseq 6000

### DIFF
--- a/templates/forms.html
+++ b/templates/forms.html
@@ -17,7 +17,7 @@
       <input type="text" id="flowcell" name="flowcell" pattern="^\w+$">
       <div></div>
       <h2>Reverse Complement Index2?</h2>
-      <label for="RC">RC Index2</label>
+      <label for="RC">RC Index2 (Novaseq 6000)</label>
       <input type="checkbox" id="checkbox_rc" name="checkbox_rc">
     </div>
     <div class="form-group">


### PR DESCRIPTION
to make it easier for the lab we add a little text to the label for the button that reverse complements index 2 saying novaseq 6000, this was requested but can also be helpful for us: https://knowledge.illumina.com/software/general/software-general-reference_material-list/000001800