### PR TITLE
reverse complement index2

### DIFF
--- a/samplesheet.py
+++ b/samplesheet.py
@@ -98,7 +98,7 @@ class singleCellSheet:
                             self.dual_index_kits[index_kit]
                             .loc[
                                 self.dual_index_kits[index_kit].index_name == row.index,
-                                "index2_workflow_b(i5)",
+                                "index2_workflow_a(i5)",
                             ]
                             .values[0]
                         )


### PR DESCRIPTION
This PR address the request from @j-braeunig:
```
Here are the Index plates:
https://github.com/ctg-lund/SampleSheetGenerator/blob/main/data/Dual_Index_Kit_TT_Set_A.csv
and we would need the sample sheet generator to grab information from index2_workflow_a(i5) instead of index2_workflow_b(i5).
```